### PR TITLE
在PlayerEvent.BreakSpeed中使用修改后的挖掘速度

### DIFF
--- a/src/main/java/com/xiaoyue/celestial_artifacts/events/CAGeneralEventHandler.java
+++ b/src/main/java/com/xiaoyue/celestial_artifacts/events/CAGeneralEventHandler.java
@@ -55,7 +55,7 @@ public class CAGeneralEventHandler {
 		for (var e : CurioCacheCap.HOLDER.get(player).getFeature(FeatureType.MINING)) {
 			factor *= e.getBreakFactor(player);
 		}
-		event.setNewSpeed((float) (event.getOriginalSpeed() * factor));
+		event.setNewSpeed((float) (event.getNewSpeed() * factor));
 	}
 
 


### PR DESCRIPTION
使用原始速度会导致其他mod在此之前做出的修改失效